### PR TITLE
added loihi_rl submodule to ncl_modules_contrib

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "nxsdk_modules_contrib/loihi_rl"]
+	path = nxsdk_modules_contrib/loihi_rl
+	url = https://github.com/wilkieolin/loihi_rl


### PR DESCRIPTION
This pull request adds my loihi_rl repository as a submodule within the ncl_modules_contrib folder. This repository contains both the ProcessNodes framework and the reinforcement learning tasks which utilize it.